### PR TITLE
Can now add an exempt date to each repository

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -292,6 +292,20 @@ files = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pytz"
 version = "2024.1"
 description = "World timezone definitions, modern and historical"
@@ -338,6 +352,17 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "urllib3"
@@ -429,4 +454,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "e2fa6f5a030c515ea405381bf3eeea02cdcf6419094ec6ec3c1da7bda3032a76"
+content-hash = "810843ddf1ad1463318891edbff27a4fc6954a6eb1f48555970e5ad2fecb77b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.12"
 requests = "^2.31.0"
 datetime = "^5.4"
 flask = "^3.0.2"
+python-dateutil = "^2.9.0.post0"
 
 
 [build-system]

--- a/repoarchivetool/templates/accessToken.html
+++ b/repoarchivetool/templates/accessToken.html
@@ -7,26 +7,26 @@
 <h1 class="ons-u-mt-l">Personal Access Token</h1>
 
 <form action="/login" method="post">
-    <div class="ons-panel ons-panel--info ons-panel--no-title ons-u-mb-s">
-      <span class="ons-panel__assistive-text ons-u-vh">Important information: </span>
-      <div class="ons-panel__body">
-        <div class="ons-field ons-question__answer">
-          <div class="ons-field">
-            <label class="ons-label ons-label--with-description" aria-describedby="pat-hint"
-              for="pat">Personal Access Token</label>
-            <span id="pat-hint" class="ons-label__description  ons-input--with-description">Keep this
-              code safe. You will need to enter it before using the tool.</span>
-            <input type="password" name="pat" id="pat" class="ons-input ons-input--text ons-input-type__input"
-              aria-describedby="pat-hint" required/>
-          </div>
-          <a class="ons-u-fs-s ons-input__post-link" href="https://github.com/ONS-Innovation/RepoArchiveTool" target="_blank">Where to get a Personal Access Token</a>
+  <div class="ons-panel ons-panel--info ons-panel--no-title ons-u-mb-s">
+    <span class="ons-panel__assistive-text ons-u-vh">Important information: </span>
+    <div class="ons-panel__body">
+      <div class="ons-field ons-question__answer">
+        <div class="ons-field">
+          <label class="ons-label ons-label--with-description" aria-describedby="pat-hint"
+            for="pat">Personal Access Token</label>
+          <span id="pat-hint" class="ons-label__description  ons-input--with-description">Keep this
+            code safe. You will need to enter it before using the tool.</span>
+          <input type="password" name="pat" id="pat" class="ons-input ons-input--text ons-input-type__input"
+            aria-describedby="pat-hint" required/>
         </div>
+        <a class="ons-u-fs-s ons-input__post-link" href="https://github.com/ONS-Innovation/RepoArchiveTool" target="_blank">Where to get a Personal Access Token</a>
       </div>
     </div>
-    <button type="submit" class="ons-btn ons-u-mb-xl">
-      <span class="ons-btn__inner"><span class="ons-btn__text">Submit Access Token</span>
-      </span>
-    </button>
+  </div>
+  <button type="submit" class="ons-btn ons-u-mb-xl">
+    <span class="ons-btn__inner"><span class="ons-btn__text">Submit Access Token</span>
+    </span>
+  </button>
 </form>
 
 <h2>If you do not have a Personal Access Token</h2>

--- a/repoarchivetool/templates/manageRepositories.html
+++ b/repoarchivetool/templates/manageRepositories.html
@@ -160,8 +160,13 @@
 					</td>
 					<td class="ons-table__cell" data-sort-value="{{ repo["dateAdded"] }}">{{ repo["dateAdded"] }}</td>
 					<td class="ons-table__cell" data-sort-value="{{ repo["lastCommit"] }}">{{ repo["lastCommit"] }}</td>
-					<td class="ons-table__cell text-centre" data-sort-value="{% if repo["keep"] %} 1 {% else %} 0 {% endif %}">
-						<input type="checkbox" class="ons-checkbox__input ons-js-checkbox" onchange="window.location.replace(`/change_keep_flag?repoName={{ repo['name'] }}`)" {% if repo["keep"] %} checked {% endif %}>
+					<td class="ons-table__cell text-centre" data-sort-value="{% if repo["exemptUntil"] != "1900-01-01" %} 1 {% else %} 0 {% endif %}">
+						{% if repo["exemptUntil"] == "1900-01-01" %}
+							<a href="/set_exempt_date?repoName={{ repo["name"] }}">Set Date</a>
+						{% else %}
+							<i>Until {{ repo["exemptUntil"] }}</i>
+							<a href="/confirm?message=Are%20you%20sure%20you%20want%20to%20remove%20the%20archive%20excemption%20date%20for%20{{ repo["name"] }}?&cancelUrl=/manage_repositories&confirmUrl=/clear_exempt_date?repoName={{ repo["name"] }}">Clear</a>
+						{% endif %}
 					</td>
 				</tr>
 			{% endfor %}

--- a/repoarchivetool/templates/setExemptDate.html
+++ b/repoarchivetool/templates/setExemptDate.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+
+{% block pagetitle %}Repository Archive Tool - Set Exempt Date{% endblock %}
+
+{% block head %}
+	<script>
+		function checkSelectValue(){
+			select = document.getElementById("date");
+			selectValue = select.value;
+
+			html = `
+				<div id="monthInput">
+					<label class="ons-label ons-u-mt-s" for="months">Number of Months</label>
+					<input type="number" id="months" name="months" class="ons-input ons-input--text ons-input-type__input" min=13 required />
+				</div>
+			`
+
+			if(selectValue == -1){
+				select.insertAdjacentHTML("afterend", html);
+			}
+			else{
+				extraInput = document.getElementById("monthInput");
+
+				if(extraInput != null){
+					extraInput.remove();
+				}
+			}
+		}
+	</script>
+{% endblock %}
+
+{% block body %}
+
+  <h1 class="ons-u-mt-l">Set Exempt Date for {{ repoName }}</h1>
+
+	<form action="/set_exempt_date?repoName={{ repoName }}" method="post">
+		<div class="ons-panel ons-panel--info ons-panel--no-title ons-u-mb-s">
+			<span class="ons-panel__assistive-text ons-u-vh">Important information: </span>
+			<div class="ons-panel__body">
+				<div class="ons-field ons-question__answer">
+					<div class="ons-field">
+						<label class="ons-label ons-label--with-description" aria-describedby="date-hint"
+							for="date">Exempt for</label>
+						<span id="date-hint" class="ons-label__description  ons-input--with-description">This repository will not be archived until <b>after</b> this amount of months.</span>
+
+						<select id="date" name="date" class="ons-input ons-input--select" aria-describedby="date-hint" onchange="checkSelectValue()" required>
+							<option value="" selected disabled>Select an option</option>
+							<option value="3">3 Months</option>
+							<option value="6">6 Months</option>
+							<option value="12">12 Months</option>
+							<option value="-1">More than 12 Months</option>
+						</select>
+					</div>
+				</div>
+			</div>
+		</div>
+		<button type="submit" class="ons-btn ons-u-mb-xl">
+			<span class="ons-btn__inner"><span class="ons-btn__text">Submit</span>
+			</span>
+		</button>
+		<button type="button" class="ons-btn ons-btn--secondary" onclick="window.location.replace('/manage_repositories')">
+			<span class="ons-btn__inner"><span class="ons-btn__text">Cancel</span>
+			</span>
+		  </button>
+	</form>
+
+{% endblock %}


### PR DESCRIPTION
Process change for marking a repository as exempt to the archiving process within manage_repositories.

Can now add a date it'll be exempt until or clear it

Before rendering manage_repositories, the backend will check to see if any repos' exempt dates are less than the current date. If they are, clear them and set the date added to today (maybe send an email here in the future???).